### PR TITLE
Detect redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Please refrain from spam or asking for questions that infringe upon a Service's 
 <a href="https://github.com/shirt-dev"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/2660574?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt=""/></a>
 <a href="https://github.com/nyuszika7h"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/482367?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt=""/></a>
 <a href="https://github.com/bccornfo"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/98013276?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt=""/></a>
+<a href="https://github.com/Arias800"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/24809312?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt=""/></a>
 
 ## License
 

--- a/devine/core/manifests/dash.py
+++ b/devine/core/manifests/dash.py
@@ -49,6 +49,9 @@ class DASH:
             raise TypeError(f"Expected session to be a {Session}, not {session!r}")
 
         res = session.get(url, **args)
+        if res.url != url:
+            url = res.url
+
         if not res.ok:
             raise requests.ConnectionError(
                 "Failed to request the MPD document.",


### PR DESCRIPTION
If the manifest is hidden behind a redirect, the url is not updated and the segments are created with the old url. I found a French service where this situation occurred.

After this change, it was possible to correctly parse the mpd.