### PR TITLE
Fix cookie import across drives in `auth add`

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Please refrain from spam or asking for questions that infringe upon a Service's 
 <a href="https://github.com/nyuszika7h"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/482367?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt=""/></a>
 <a href="https://github.com/bccornfo"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/98013276?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt=""/></a>
 <a href="https://github.com/Arias800"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/24809312?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt=""/></a>
+<a href="https://github.com/varyg1001"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/88599103?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt=""/></a>
 
 ## License
 

--- a/devine/commands/auth.py
+++ b/devine/commands/auth.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import shutil
 import tkinter.filedialog
 from collections import defaultdict
 from pathlib import Path
@@ -243,7 +244,7 @@ def add(ctx: click.Context, profile: str, service: str, cookie: Optional[str] = 
         if final_path.exists():
             log.error(f"A Cookie file for the Profile {profile} on {service} already exists.")
             sys.exit(1)
-        cookie = cookie.rename(final_path)
+        shutil.move(cookie, final_path)
         log.info(f"Moved Cookie file to: {cookie}")
 
     if credential:

--- a/devine/commands/dl.py
+++ b/devine/commands/dl.py
@@ -5,6 +5,7 @@ import logging
 import math
 import random
 import re
+import shutil
 import sys
 import time
 import traceback
@@ -674,7 +675,7 @@ class dl:
         final_dir.mkdir(parents=True, exist_ok=True)
         final_path = final_dir / f"{final_filename}{muxed_path.suffix}"
 
-        muxed_path.rename(final_path)
+        shutil.move(muxed_path, final_path)
         self.log.info(f" + Moved to {final_path}")
 
     @staticmethod

--- a/devine/core/tracks/track.py
+++ b/devine/core/tracks/track.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import re
+import shutil
 import subprocess
 from enum import Enum
 from pathlib import Path
@@ -312,7 +313,8 @@ class Track:
         if not self.path:
             return False
         target = Path(target)
-        ok = self.path.rename(target).resolve() == target.resolve()
+
+        ok = Path(shutil.move(self.path, target)).resolve() == target.resolve()
         if ok:
             self.path = target
         return ok
@@ -326,7 +328,7 @@ class Track:
         if not target.exists() or not self.path:
             return False
         self.path.unlink()
-        ok = target.rename(self.path) == self.path
+        ok = Path(shutil.move(target, self.path)).resolve() == self.path.resolve()
         if not ok:
             return False
         return self.move(target)


### PR DESCRIPTION
Path.rename() cause problem on WSL if cookies not on the virtual drive.