### PR TITLE
always define track.path if track.descriptor is URL

### DIFF
--- a/devine/commands/dl.py
+++ b/devine/commands/dl.py
@@ -630,6 +630,7 @@ class dl:
                 service.session.headers,
                 proxy if track.needs_proxy else None
             ))
+            track.path = save_path
 
             if not track.drm and isinstance(track, (Video, Audio)):
                 try:
@@ -645,7 +646,6 @@ class dl:
                     prepare_drm(drm)
                 drm.decrypt(save_path)
                 track.drm = None
-                track.path = save_path
                 if callable(track.OnDecrypted):
                     track.OnDecrypted(track)
         else:


### PR DESCRIPTION
In case of subtitle there wasn't track.path and causes an error

```
Traceback (most recent call last):
  File "/home/varyg/.pyenv/versions/3.11.0/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/bin/devine/devine/commands/dl.py", line 659, in download_track
    if track.path.stat().st_size <= 3:  # Empty UTF-8 BOM == 3 bytes
       ^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'stat'
```