### PR TITLE
DASH: improved forced subtitle recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Please refrain from spam or asking for questions that infringe upon a Service's 
 <a href="https://github.com/bccornfo"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/98013276?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt=""/></a>
 <a href="https://github.com/Arias800"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/24809312?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt=""/></a>
 <a href="https://github.com/varyg1001"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/88599103?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt=""/></a>
+<a href="https://github.com/Hollander-1908"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/93162595?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt=""/></a>
 
 ## License
 

--- a/devine/core/manifests/dash.py
+++ b/devine/core/manifests/dash.py
@@ -124,7 +124,8 @@ class DASH:
                     for x in adaptation_set.findall("Accessibility")
                 )
                 forced = any(
-                    (x.get("schemeIdUri"), x.get("value")) == ("urn:mpeg:dash:role:2011", "forced-subtitle")
+                    x.get("schemeIdUri") == "urn:mpeg:dash:role:2011"
+                    and x.get("value") in ("forced-subtitle", "forced_subtitle")
                     for x in adaptation_set.findall("Role")
                 )
                 cc = any(


### PR DESCRIPTION
Some manifests uses value `forced_subtitle` instead of the regular `forced-subtitle`. This way both are recognized.