### PR TITLE
Add option for automatic subtitle character encoding normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Please refrain from spam or asking for questions that infringe upon a Service's 
 <a href="https://github.com/Arias800"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/24809312?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="Arias800"/></a>
 <a href="https://github.com/varyg1001"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/88599103?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="varyg1001"/></a>
 <a href="https://github.com/Hollander-1908"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/93162595?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="Hollander-1908"/></a>
+<a href="https://github.com/Shivelight"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/20620780?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="Shivelight"/></a>
 
 ## Licensing
 

--- a/devine/commands/dl.py
+++ b/devine/commands/dl.py
@@ -918,13 +918,14 @@ class dl:
                             progress(downloaded="Decrypting", completed=0, total=100)
                             drm.decrypt(save_path)
                             track.drm = None
-                            if isinstance(track, Subtitle):
-                                data = track.path.read_bytes()
-                                content = Subtitle.fix_encoding(data)
-                                track.path.write_bytes(content)
                             if callable(track.OnDecrypted):
                                 track.OnDecrypted(track)
                             progress(downloaded="Decrypted", completed=100)
+
+                        if isinstance(track, Subtitle):
+                            track_data = track.path.read_bytes()
+                            track_data = Subtitle.fix_encoding(track_data)
+                            track.path.write_bytes(track_data)
 
                         progress(downloaded="Downloaded")
                 except KeyboardInterrupt:

--- a/devine/commands/dl.py
+++ b/devine/commands/dl.py
@@ -918,6 +918,10 @@ class dl:
                             progress(downloaded="Decrypting", completed=0, total=100)
                             drm.decrypt(save_path)
                             track.drm = None
+                            if isinstance(track, Subtitle) and track.auto_fix_encoding:
+                                data = track.path.read_bytes()
+                                content = Subtitle.fix_encoding(data)
+                                track.path.write_bytes(content)
                             if callable(track.OnDecrypted):
                                 track.OnDecrypted(track)
                             progress(downloaded="Decrypted", completed=100)

--- a/devine/commands/dl.py
+++ b/devine/commands/dl.py
@@ -52,7 +52,7 @@ from devine.core.services import Services
 from devine.core.titles import Movie, Song, Title_T
 from devine.core.titles.episode import Episode
 from devine.core.tracks import Audio, Subtitle, Tracks, Video
-from devine.core.utilities import get_binary_path, is_close_match, time_elapsed_since
+from devine.core.utilities import get_binary_path, is_close_match, time_elapsed_since, try_ensure_utf8
 from devine.core.utils.click_types import LANGUAGE_RANGE, QUALITY_LIST, SEASON_RANGE, ContextData
 from devine.core.utils.collections import merge_dict
 from devine.core.utils.subprocess import ffprobe
@@ -924,7 +924,7 @@ class dl:
 
                         if isinstance(track, Subtitle):
                             track_data = track.path.read_bytes()
-                            track_data = Subtitle.fix_encoding(track_data)
+                            track_data = try_ensure_utf8(track_data)
                             track.path.write_bytes(track_data)
 
                         progress(downloaded="Downloaded")

--- a/devine/commands/dl.py
+++ b/devine/commands/dl.py
@@ -918,7 +918,7 @@ class dl:
                             progress(downloaded="Decrypting", completed=0, total=100)
                             drm.decrypt(save_path)
                             track.drm = None
-                            if isinstance(track, Subtitle) and track.auto_fix_encoding:
+                            if isinstance(track, Subtitle):
                                 data = track.path.read_bytes()
                                 content = Subtitle.fix_encoding(data)
                                 track.path.write_bytes(content)

--- a/devine/core/manifests/dash.py
+++ b/devine/core/manifests/dash.py
@@ -31,7 +31,7 @@ from devine.core.downloaders import downloader
 from devine.core.downloaders import requests as requests_downloader
 from devine.core.drm import Widevine
 from devine.core.tracks import Audio, Subtitle, Tracks, Video
-from devine.core.utilities import is_close_match
+from devine.core.utilities import is_close_match, try_ensure_utf8
 from devine.core.utils.xml import load_xml
 
 
@@ -471,11 +471,11 @@ class DASH:
                 if init_data:
                     f.write(init_data)
                 for segment_file in sorted(save_dir.iterdir()):
-                    data = segment_file.read_bytes()
+                    segment_data = segment_file.read_bytes()
                     # TODO: fix encoding after decryption?
                     if not drm and isinstance(track, Subtitle):
-                        data = Subtitle.fix_encoding(data)
-                    f.write(data)
+                        segment_data = try_ensure_utf8(segment_data)
+                    f.write(segment_data)
                     segment_file.unlink()
 
             if drm:

--- a/devine/core/manifests/dash.py
+++ b/devine/core/manifests/dash.py
@@ -471,7 +471,11 @@ class DASH:
                 if init_data:
                     f.write(init_data)
                 for segment_file in sorted(save_dir.iterdir()):
-                    f.write(segment_file.read_bytes())
+                    data = segment_file.read_bytes()
+                    # TODO: fix encoding after decryption?
+                    if not drm and isinstance(track, Subtitle) and track.auto_fix_encoding:
+                        data = Subtitle.fix_encoding(data)
+                    f.write(data)
                     segment_file.unlink()
 
             if drm:

--- a/devine/core/manifests/dash.py
+++ b/devine/core/manifests/dash.py
@@ -473,7 +473,7 @@ class DASH:
                 for segment_file in sorted(save_dir.iterdir()):
                     data = segment_file.read_bytes()
                     # TODO: fix encoding after decryption?
-                    if not drm and isinstance(track, Subtitle) and track.auto_fix_encoding:
+                    if not drm and isinstance(track, Subtitle):
                         data = Subtitle.fix_encoding(data)
                     f.write(data)
                     segment_file.unlink()

--- a/devine/core/manifests/hls.py
+++ b/devine/core/manifests/hls.py
@@ -28,7 +28,7 @@ from devine.core.downloaders import downloader
 from devine.core.downloaders import requests as requests_downloader
 from devine.core.drm import DRM_T, ClearKey, Widevine
 from devine.core.tracks import Audio, Subtitle, Tracks, Video
-from devine.core.utilities import is_close_match
+from devine.core.utilities import is_close_match, try_ensure_utf8
 
 
 class HLS:
@@ -301,10 +301,10 @@ class HLS:
 
         with open(save_path, "wb") as f:
             for segment_file in sorted(save_dir.iterdir()):
-                data = segment_file.read_bytes()
+                segment_data = segment_file.read_bytes()
                 if isinstance(track, Subtitle):
-                    data = Subtitle.fix_encoding(data)
-                f.write(data)
+                    segment_data = try_ensure_utf8(segment_data)
+                f.write(segment_data)
                 segment_file.unlink()
 
         progress(downloaded="Downloaded")

--- a/devine/core/manifests/hls.py
+++ b/devine/core/manifests/hls.py
@@ -302,7 +302,7 @@ class HLS:
         with open(save_path, "wb") as f:
             for segment_file in sorted(save_dir.iterdir()):
                 data = segment_file.read_bytes()
-                if isinstance(track, Subtitle) and track.auto_fix_encoding:
+                if isinstance(track, Subtitle):
                     data = Subtitle.fix_encoding(data)
                 f.write(data)
                 segment_file.unlink()

--- a/devine/core/manifests/hls.py
+++ b/devine/core/manifests/hls.py
@@ -301,7 +301,10 @@ class HLS:
 
         with open(save_path, "wb") as f:
             for segment_file in sorted(save_dir.iterdir()):
-                f.write(segment_file.read_bytes())
+                data = segment_file.read_bytes()
+                if isinstance(track, Subtitle) and track.auto_fix_encoding:
+                    data = Subtitle.fix_encoding(data)
+                f.write(data)
                 segment_file.unlink()
 
         progress(downloaded="Downloaded")

--- a/devine/core/tracks/subtitle.py
+++ b/devine/core/tracks/subtitle.py
@@ -7,6 +7,7 @@ from enum import Enum
 from io import BytesIO
 from typing import Any, Iterable, Optional
 
+import chardet
 import pycaption
 from construct import Container
 from pycaption import Caption, CaptionList, CaptionNode, WebVTTReader
@@ -353,16 +354,27 @@ class Subtitle(Track):
         """
         Make sure the caption is UTF-8-encoded.
 
-        The rationale behind this function is that some services use ISO-8859-1 (latin1)
-        or Windows-1252 (CP-1252) instead of UTF-8 encoding, whether intentionally or accidentally.
-        Some services even stream subtitles with malformed/mixed encoding (each segment has a different encoding).
+        The rationale behind this function is that some services use ISO-8859-1 (latin1) or
+        Windows-1252 (CP-1252) instead of UTF-8 encoding, whether intentionally or accidentally.
+        Some services even stream subtitles with malformed/mixed encoding (each segment having a
+        different encoding).
+
+        If all decoding attempts fail, the original data as-received will be returned.
         """
         try:
             data.decode("utf8")
             return data
         except UnicodeDecodeError:
-            # CP-1252 is a superset of latin1
-            return data.decode("cp1252").encode("utf8")
+            try:
+                # CP-1252 is a superset of latin1
+                return data.decode("cp1252").encode("utf8")
+            except UnicodeDecodeError:
+                try:
+                    # last ditch effort to detect encoding
+                    detection_result = chardet.detect(data)
+                    return data.decode(detection_result["encoding"]).encode("utf8")
+                except UnicodeDecodeError:
+                    return data
 
     def strip_hearing_impaired(self) -> None:
         """

--- a/devine/core/tracks/subtitle.py
+++ b/devine/core/tracks/subtitle.py
@@ -7,7 +7,6 @@ from enum import Enum
 from io import BytesIO
 from typing import Any, Iterable, Optional
 
-import chardet
 import pycaption
 from construct import Container
 from pycaption import Caption, CaptionList, CaptionNode, WebVTTReader
@@ -348,33 +347,6 @@ class Subtitle(Track):
                         captions.append(caption)
 
         return captions, language
-
-    @staticmethod
-    def fix_encoding(data: bytes) -> bytes:
-        """
-        Make sure the caption is UTF-8-encoded.
-
-        The rationale behind this function is that some services use ISO-8859-1 (latin1) or
-        Windows-1252 (CP-1252) instead of UTF-8 encoding, whether intentionally or accidentally.
-        Some services even stream subtitles with malformed/mixed encoding (each segment having a
-        different encoding).
-
-        If all decoding attempts fail, the original data as-received will be returned.
-        """
-        try:
-            data.decode("utf8")
-            return data
-        except UnicodeDecodeError:
-            try:
-                # CP-1252 is a superset of latin1
-                return data.decode("cp1252").encode("utf8")
-            except UnicodeDecodeError:
-                try:
-                    # last ditch effort to detect encoding
-                    detection_result = chardet.detect(data)
-                    return data.decode(detection_result["encoding"]).encode("utf8")
-                except UnicodeDecodeError:
-                    return data
 
     def strip_hearing_impaired(self) -> None:
         """

--- a/devine/core/tracks/subtitle.py
+++ b/devine/core/tracks/subtitle.py
@@ -72,7 +72,7 @@ class Subtitle(Track):
             raise ValueError(f"The Content Profile '{profile}' is not a supported Subtitle Codec")
 
     def __init__(self, *args: Any, codec: Subtitle.Codec, cc: bool = False, sdh: bool = False, forced: bool = False,
-                 auto_fix_encoding: bool = False, **kwargs: Any):
+                 **kwargs: Any):
         """
         Information on Subtitle Types:
             https://bit.ly/2Oe4fLC (3PlayMedia Blog on SUB vs CC vs SDH).
@@ -122,8 +122,6 @@ class Subtitle(Track):
                      no other way to reliably work with Forced subtitles where multiple
                      forced subtitles may be in the output file. Just know what to expect
                      with "forced" subtitles.
-            auto_fix_encoding: Try to normalize subtitle character encoding to UTF-8. See
-                                `Subtitle.fix_encoding` docstring for more information.
         """
         super().__init__(*args, **kwargs)
         self.codec = codec
@@ -134,7 +132,6 @@ class Subtitle(Track):
         self.forced = bool(forced)
         if (self.cc or self.sdh) and self.forced:
             raise ValueError("A text track cannot be CC/SDH as well as Forced.")
-        self.auto_fix_encoding = auto_fix_encoding
 
     def get_track_name(self) -> Optional[str]:
         """Return the base Track Name."""

--- a/poetry.lock
+++ b/poetry.lock
@@ -295,6 +295,17 @@ files = [
 ]
 
 [[package]]
+name = "chardet"
+version = "5.2.0"
+description = "Universal encoding detector for Python 3"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
+    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.2.0"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -1769,4 +1780,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.0,<3.12"
-content-hash = "d19aedf3a21dff6327497d42b56dbff63cef4d2899fa886c52c058e5439fee87"
+content-hash = "725552b13f9ba04c99b77a5cc96eef121abdd80eb5e67188981f6940fdc88015"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ sortedcontainers = "^2.4.0"
 subtitle-filter = "^1.4.6"
 Unidecode = "^1.3.6"
 urllib3 = "^2.0.4"
+chardet = "^5.2.0"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^3.4.0"


### PR DESCRIPTION
The rationale behind this function is that some services use ISO-8859-1 (latin1) or Windows-1252 (CP-1252) instead of UTF-8 encoding, whether intentionally or accidentally. Some services even stream subtitles with malformed/mixed encoding (each segment has a different encoding).