### PR TITLE
Events not working as expected

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Please refrain from spam or asking for questions that infringe upon a Service's 
 <a href="https://github.com/varyg1001"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/88599103?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="varyg1001"/></a>
 <a href="https://github.com/Hollander-1908"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/93162595?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="Hollander-1908"/></a>
 <a href="https://github.com/Shivelight"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/20620780?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="Shivelight"/></a>
+<a href="https://github.com/knowhere01"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/113712042?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="knowhere01"/></a>
 
 ## Licensing
 

--- a/devine/core/events.py
+++ b/devine/core/events.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from enum import Enum
 from typing import Any, Callable
 
@@ -25,10 +26,11 @@ class Events:
 
     def reset(self):
         """Reset Event Observer clearing all Subscriptions."""
-        self.__subscriptions = self.__ephemeral = {
+        self.__subscriptions = {
             k: []
             for k in Events.Types.__members__.values()
         }
+        self.__ephemeral = deepcopy(self.__subscriptions)
 
     def subscribe(self, event_type: Events.Types, callback: Callable, ephemeral: bool = False) -> None:
         """


### PR DESCRIPTION
Events is not working as expected as `self.__subscriptions` and `self.__ephemeral` are pointing to the same object.

Even though, it is separated when initialize but [this line](https://github.com/devine-dl/devine/blob/master/devine/commands/dl.py#L332) that calls reset and make both variable pointing to the same object which make [this line](https://github.com/devine-dl/devine/blob/994ab152a40f9c53881bc9bf2280156a7193825c/devine/core/events.py#L74) clear both `self.__subscriptions` and `self.__ephemeral`.

I believe this is not intended behavior cause it make only some of the tracks (in my case 2 tracks) got passed into on_xxx in service class.
