### PR TITLE
Check if width and height is digit if it's an str

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Please refrain from spam or asking for questions that infringe upon a Service's 
 <a href="https://github.com/Hollander-1908"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/93162595?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="Hollander-1908"/></a>
 <a href="https://github.com/Shivelight"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/20620780?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="Shivelight"/></a>
 <a href="https://github.com/knowhere01"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/113712042?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="knowhere01"/></a>
+<a href="https://github.com/retouching"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/33735357?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="retouching"/></a>
 
 ## Licensing
 

--- a/devine/core/tracks/video.py
+++ b/devine/core/tracks/video.py
@@ -194,9 +194,9 @@ class Video(Track):
             raise TypeError(f"Expected range_ to be a {Video.Range}, not {range_!r}")
         if not isinstance(bitrate, (str, int, float, type(None))):
             raise TypeError(f"Expected bitrate to be a {str}, {int}, or {float}, not {bitrate!r}")
-        if not isinstance(width, (int, type(None))):
+        if not isinstance(width, (int, str, type(None))):
             raise TypeError(f"Expected width to be a {int}, not {width!r}")
-        if not isinstance(height, (int, type(None))):
+        if not isinstance(height, (int, str, type(None))):
             raise TypeError(f"Expected height to be a {int}, not {height!r}")
         if not isinstance(fps, (str, int, float, type(None))):
             raise TypeError(f"Expected fps to be a {str}, {int}, or {float}, not {fps!r}")
@@ -212,12 +212,12 @@ class Video(Track):
         try:
             self.width = int(width or 0) or None
         except ValueError as e:
-            raise ValueError(f"Expected width to be a number, {e}")
+            raise ValueError(f"Expected width to be a number, not {width!r}, {e}")
 
         try:
             self.height = int(height or 0) or None
         except ValueError as e:
-            raise ValueError(f"Expected height to be a number, {e}")
+            raise ValueError(f"Expected height to be a number, not {height!r}, {e}")
 
         try:
             self.fps = (FPS.parse(str(fps)) or None) if fps else None


### PR DESCRIPTION
Sometimes, height or width can be get as string (tested on a DASH stream)

![image](https://github.com/devine-dl/devine/assets/33735357/1ee538f3-43dc-474a-b6e9-6c61ef35edaa)

The idea is just to check if is digit to avoid this problem