### PR TITLE
Fix uppercase letters in the fonts extension - Font attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Please refrain from spam or asking for questions that infringe upon a Service's 
 <a href="https://github.com/Shivelight"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/20620780?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="Shivelight"/></a>
 <a href="https://github.com/knowhere01"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/113712042?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="knowhere01"/></a>
 <a href="https://github.com/retouching"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/33735357?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="retouching"/></a>
+<a href="https://github.com/pandamoon21"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/33972938?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="pandamoon21"/></a>
 
 ## Licensing
 

--- a/devine/core/tracks/attachment.py
+++ b/devine/core/tracks/attachment.py
@@ -37,7 +37,7 @@ class Attachment:
             mime_type = {
                 ".ttf": "application/x-truetype-font",
                 ".otf": "application/vnd.ms-opentype"
-            }.get(path.suffix, mimetypes.guess_type(path)[0])
+            }.get(path.suffix.lower(), mimetypes.guess_type(path)[0])
             if not mime_type:
                 raise ValueError("The attachment mime-type could not be automatically detected.")
 


### PR DESCRIPTION
There is a case when a font has uppercase letters in the extension. It'll raise `ValueError` despite the font is available.
```
.ttf
.TTF

.otf
.OTF
```
Maybe there is a better approach to fix this, but this simple fix is enough I think.