### PR TITLE
Adding Arm64 OSX Shaka support

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Please refrain from spam or asking for questions that infringe upon a Service's 
 <a href="https://github.com/knowhere01"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/113712042?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="knowhere01"/></a>
 <a href="https://github.com/retouching"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/33735357?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="retouching"/></a>
 <a href="https://github.com/pandamoon21"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/33972938?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="pandamoon21"/></a>
+<a href="https://github.com/adbbbb"><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/56319336?v=4&h=25&w=25&fit=cover&mask=circle&maxage=7d" alt="adbbbb"/></a>
 
 ## Licensing
 

--- a/devine/core/binaries.py
+++ b/devine/core/binaries.py
@@ -26,6 +26,7 @@ ShakaPackager = find(
     "shaka-packager",
     "packager",
     f"packager-{__shaka_platform}",
+    f"packager-{__shaka_platform}-arm64",
     f"packager-{__shaka_platform}-x64"
 )
 Aria2 = find("aria2c", "aria2")


### PR DESCRIPTION
This PR adds support for shaka-packager arm64 OSX (M series) binaries. Thus when the `find` function parses PATHs on M1 macs, `packager-osx-arm64` will be considered valid, and can then decrypt files. 