### PR TITLE
fix(dl): delete old file after repackage

### DIFF
--- a/devine/core/tracks/track.py
+++ b/devine/core/tracks/track.py
@@ -542,7 +542,7 @@ class Track:
             else:
                 raise
 
-        self.path.unlink()
+        original_path.unlink()
         self.path = output_path
 
 

--- a/devine/core/tracks/track.py
+++ b/devine/core/tracks/track.py
@@ -542,6 +542,7 @@ class Track:
             else:
                 raise
 
+        self.path.unlink()
         self.path = output_path
 
 


### PR DESCRIPTION
When devine repackage a file, it not delete old file