### PR TITLE
ignore demuxer info messages

### DIFF
--- a/devine/core/drm/widevine.py
+++ b/devine/core/drm/widevine.py
@@ -274,6 +274,9 @@ class Widevine:
                 if "Insufficient bits in bitstream for given AVC profile" in line:
                     # this is a warning and is something we don't have to worry about
                     continue
+                if "I0" in line:
+                    # ignore demuxer info messages
+                    continue
                 shaka_log_buffer += f"{line.strip()}\n"
 
             if shaka_log_buffer:


### PR DESCRIPTION
The new Shaka versions introduced some kind of info messages for the demuxer.
This results in spamming the devine output with these infos.

![image](https://github.com/devine-dl/devine/assets/80389932/870e9e89-f332-46da-8a5c-1ec589a77071)


