### PR TITLE
Allow configuring dynamic save paths

### DIFF
--- a/devine/commands/dl.py
+++ b/devine/commands/dl.py
@@ -729,7 +729,7 @@ class dl:
 
                 for muxed_path in muxed_paths:
                     media_info = MediaInfo.parse(muxed_path)
-                    final_dir = config.directories.downloads
+                    final_dir = Path(str(config.directories.downloads).format(**title.__dict__))
                     final_filename = title.get_filename(media_info, show_service=not no_source)
 
                     if not no_folder and isinstance(title, (Episode, Song)):

--- a/devine/commands/dl.py
+++ b/devine/commands/dl.py
@@ -729,7 +729,10 @@ class dl:
 
                 for muxed_path in muxed_paths:
                     media_info = MediaInfo.parse(muxed_path)
-                    final_dir = Path(str(config.directories.downloads).format(**title.__dict__))
+                    final_dir = config.directories.downloads
+                    if isinstance(title, Episode):
+                        final_dir = Path(str(config.directories.downloads).format(**title.__dict__))
+
                     final_filename = title.get_filename(media_info, show_service=not no_source)
 
                     if not no_folder and isinstance(title, (Episode, Song)):


### PR DESCRIPTION
Inspired by https://github.com/devine-dl/devine/issues/97

The patch allows you to specify a downloads folder where the values are dynamically filled in based on the contents of `title.__dict__`

devine.yaml:
```yaml
dl:
  no_folder: True

directories:
  downloads: "~/Downloads/{title}/Season {season:02}"
```