### PR TITLE
Feature: Env Check Dependencies Command

### DIFF
--- a/devine/core/utils/osenvironment.py
+++ b/devine/core/utils/osenvironment.py
@@ -1,0 +1,24 @@
+import platform
+
+
+def get_os_arch(name: str) -> str:
+    """Builds a name-os-arch based on the input name, system, architecture."""
+    os_name = platform.system().lower()
+    os_arch = platform.machine().lower()
+
+    # Map platform.system() output to desired OS name
+    if os_name == "windows":
+        os_name = "win"
+    elif os_name == "darwin":
+        os_name = "osx"
+    else:
+        os_name = "linux"
+
+    # Map platform.machine() output to desired architecture
+    if os_arch in ["x86_64", "amd64"]:
+        os_arch = "x64"
+    elif os_arch == "arm64":
+        os_arch = "arm64"
+
+    # Construct the dependency name in the desired format using the input name
+    return f"{name}-{os_name}-{os_arch}"


### PR DESCRIPTION
This addresses [Issue #125](https://github.com/devine-dl/devine/issues/125)

Create core/utils/osenvironment.py for determining a package name based on input name, operating system, and architecture

Added env check command func

Updated env info to add fold overflow on long paths, it bugged me how long paths where being truncated